### PR TITLE
Updated deprecated query syntax. Updated neo4j version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask==0.10.1
-neo4j-driver==1.6.1
+neo4j==1.7.6


### PR DESCRIPTION
The current version did not work with Neo4j 4.0.1 due to deprecated query syntax.  Updated the queries and using a more recent version of the neo4j library.